### PR TITLE
Extract shared Nav and Footer into reusable components

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -1,0 +1,25 @@
+import Link from "next/link";
+
+export default function Footer() {
+  return (
+    <footer className="py-10 px-6 border-t border-neutral-900">
+      <div className="max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
+        <span className="text-neutral-600 text-sm">MIT License</span>
+        <div className="flex items-center gap-6 text-sm text-neutral-500">
+          <a href="https://docs.forcecalendar.org" className="hover:text-white transition-colors">
+            Docs
+          </a>
+          <a href="https://github.com/forcecalendar" className="hover:text-white transition-colors">
+            GitHub
+          </a>
+          <a href="https://www.npmjs.com/org/forcecalendar" className="hover:text-white transition-colors">
+            npm
+          </a>
+          <Link href="/playground" className="hover:text-white transition-colors">
+            Playground
+          </Link>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/app/components/Nav.tsx
+++ b/app/components/Nav.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+
+export default function Nav({ cta = "playground" }: { cta?: "playground" | "none" }) {
+  return (
+    <nav className="fixed top-0 w-full z-50 bg-black/80 backdrop-blur-xl border-b border-neutral-900">
+      <div className="max-w-5xl mx-auto px-6 h-14 flex items-center justify-between">
+        <Link href="/" className="text-lg font-medium text-white">
+          <span className="italic">force</span>Calendar
+        </Link>
+        <div className="hidden md:flex items-center gap-6 text-sm">
+          <Link href="/core" className="text-neutral-400 hover:text-white transition-colors">
+            Core
+          </Link>
+          <Link href="/interface" className="text-neutral-400 hover:text-white transition-colors">
+            Interface
+          </Link>
+          <a href="https://docs.forcecalendar.org" className="text-neutral-400 hover:text-white transition-colors">
+            Docs
+          </a>
+          <a href="https://github.com/forcecalendar" className="text-neutral-400 hover:text-white transition-colors">
+            GitHub
+          </a>
+        </div>
+        {cta === "playground" && (
+          <Link
+            href="/playground"
+            className="inline-flex items-center px-3 py-1.5 rounded-md bg-teal-500 text-black text-sm font-medium hover:bg-teal-400 transition-colors"
+          >
+            Playground
+          </Link>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/app/core/page.tsx
+++ b/app/core/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import Nav from "../components/Nav";
+import Footer from "../components/Footer";
 
 export default function CorePage() {
   const [activeTab, setActiveTab] = useState<"calendar" | "events" | "timezone">("calendar");
@@ -54,31 +56,7 @@ console.log(info.offset, info.isDST);`
 
   return (
     <div className="min-h-screen bg-black">
-      {/* Nav */}
-      <nav className="fixed top-0 w-full z-50 bg-black/80 backdrop-blur-xl border-b border-neutral-900">
-        <div className="max-w-5xl mx-auto px-6 h-14 flex items-center justify-between">
-          <Link href="/" className="text-lg font-medium text-white">
-            <span className="italic">force</span>Calendar
-          </Link>
-          <div className="flex items-center gap-6">
-            <a
-              href="https://docs.forcecalendar.org"
-              className="text-sm text-neutral-400 hover:text-white transition-colors"
-            >
-              Docs
-            </a>
-            <Link href="/playground" className="text-sm text-neutral-400 hover:text-white transition-colors">
-              Playground
-            </Link>
-            <a
-              href="https://github.com/forcecalendar"
-              className="text-sm text-neutral-400 hover:text-white transition-colors"
-            >
-              GitHub
-            </a>
-          </div>
-        </div>
-      </nav>
+      <Nav />
 
       {/* Hero */}
       <section className="pt-32 pb-20 px-6">
@@ -323,18 +301,7 @@ const calendar = new Calendar({
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="py-10 px-6 border-t border-neutral-900">
-        <div className="max-w-4xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
-          <span className="text-neutral-600 text-sm">MIT License</span>
-          <div className="flex items-center gap-6 text-sm text-neutral-500">
-            <a href="https://docs.forcecalendar.org" className="hover:text-white transition-colors">Docs</a>
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Link href="/interface" className="hover:text-white transition-colors">Interface</Link>
-            <Link href="/playground" className="hover:text-white transition-colors">Playground</Link>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/app/interface/page.tsx
+++ b/app/interface/page.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import Link from "next/link";
+import Nav from "../components/Nav";
+import Footer from "../components/Footer";
 
 export default function InterfacePage() {
   const [activeFramework, setActiveFramework] = useState<"react" | "vue" | "angular" | "lwc">("react");
@@ -42,31 +44,7 @@ function App() {
 
   return (
     <div className="min-h-screen bg-black">
-      {/* Nav */}
-      <nav className="fixed top-0 w-full z-50 bg-black/80 backdrop-blur-xl border-b border-neutral-900">
-        <div className="max-w-5xl mx-auto px-6 h-14 flex items-center justify-between">
-          <Link href="/" className="text-lg font-medium text-white">
-            <span className="italic">force</span>Calendar
-          </Link>
-          <div className="flex items-center gap-6">
-            <a
-              href="https://docs.forcecalendar.org"
-              className="text-sm text-neutral-400 hover:text-white transition-colors"
-            >
-              Docs
-            </a>
-            <Link href="/playground" className="text-sm text-neutral-400 hover:text-white transition-colors">
-              Playground
-            </Link>
-            <a
-              href="https://github.com/forcecalendar"
-              className="text-sm text-neutral-400 hover:text-white transition-colors"
-            >
-              GitHub
-            </a>
-          </div>
-        </div>
-      </nav>
+      <Nav />
 
       {/* Hero */}
       <section className="pt-32 pb-20 px-6">
@@ -361,18 +339,7 @@ function App() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="py-10 px-6 border-t border-neutral-900">
-        <div className="max-w-4xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
-          <span className="text-neutral-600 text-sm">MIT License</span>
-          <div className="flex items-center gap-6 text-sm text-neutral-500">
-            <a href="https://docs.forcecalendar.org" className="hover:text-white transition-colors">Docs</a>
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <Link href="/core" className="hover:text-white transition-colors">Core</Link>
-            <Link href="/playground" className="hover:text-white transition-colors">Playground</Link>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,35 +1,35 @@
 import Link from "next/link";
+import Nav from "./components/Nav";
+import Footer from "./components/Footer";
 
 export default function NotFound() {
   return (
-    <div className="min-h-screen bg-black flex items-center justify-center px-6">
-      <div className="text-center">
-        <h1 className="text-8xl font-bold text-white mb-4">404</h1>
-        <h2 className="text-2xl font-medium text-white mb-4">Page Not Found</h2>
-        <p className="text-neutral-400 mb-8 max-w-md mx-auto">
-          The page you&apos;re looking for doesn&apos;t exist or has been moved.
-        </p>
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-          <Link
-            href="/"
-            className="px-5 py-2.5 bg-teal-500 text-black text-sm font-medium rounded-lg hover:bg-teal-400 transition-colors"
-          >
-            Go Home
-          </Link>
-          <Link
-            href="/playground"
-            className="px-5 py-2.5 border border-neutral-800 text-white text-sm font-medium rounded-lg hover:bg-neutral-900 transition-colors"
-          >
-            Try Playground
-          </Link>
-          <a
-            href="https://docs.forcecalendar.org"
-            className="px-5 py-2.5 border border-neutral-800 text-white text-sm font-medium rounded-lg hover:bg-neutral-900 transition-colors"
-          >
-            View Docs
-          </a>
+    <div className="min-h-screen bg-black flex flex-col">
+      <Nav />
+      <div className="flex-1 flex items-center justify-center px-6">
+        <div className="text-center">
+          <h1 className="text-8xl font-bold text-white mb-4">404</h1>
+          <h2 className="text-2xl font-medium text-white mb-4">Page Not Found</h2>
+          <p className="text-neutral-400 mb-8 max-w-md mx-auto">
+            The page you&apos;re looking for doesn&apos;t exist or has been moved.
+          </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <Link
+              href="/"
+              className="px-5 py-2.5 bg-teal-500 text-black text-sm font-medium rounded-lg hover:bg-teal-400 transition-colors"
+            >
+              Go Home
+            </Link>
+            <Link
+              href="/playground"
+              className="px-5 py-2.5 border border-neutral-800 text-white text-sm font-medium rounded-lg hover:bg-neutral-900 transition-colors"
+            >
+              Try Playground
+            </Link>
+          </div>
         </div>
       </div>
+      <Footer />
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,6 @@
 import Link from "next/link";
+import Nav from "./components/Nav";
+import Footer from "./components/Footer";
 
 const featureList = [
   {
@@ -42,36 +44,7 @@ const featureList = [
 export default function Home() {
   return (
     <div className="min-h-screen bg-black">
-      <nav className="fixed top-0 w-full z-50 bg-black/80 backdrop-blur-xl border-b border-neutral-900">
-        <div className="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
-          <Link href="/" className="text-lg font-medium text-white">
-            <span className="italic">force</span>Calendar
-          </Link>
-          <div className="hidden md:flex items-center gap-6 text-sm">
-            <a href="#why" className="text-neutral-400 hover:text-white transition-colors">
-              Why
-            </a>
-            <a href="#products" className="text-neutral-400 hover:text-white transition-colors">
-              Products
-            </a>
-            <a href="#features" className="text-neutral-400 hover:text-white transition-colors">
-              Features
-            </a>
-            <a href="https://docs.forcecalendar.org" className="text-neutral-400 hover:text-white transition-colors">
-              Docs
-            </a>
-            <a href="https://github.com/forcecalendar" className="text-neutral-400 hover:text-white transition-colors">
-              GitHub
-            </a>
-          </div>
-          <Link
-            href="/playground"
-            className="inline-flex items-center px-3 py-1.5 rounded-md bg-teal-500 text-black text-sm font-medium hover:bg-teal-400 transition-colors"
-          >
-            Start with Playground
-          </Link>
-        </div>
-      </nav>
+      <Nav />
 
       <section className="pt-32 pb-20 px-6">
         <div className="max-w-4xl mx-auto text-center">
@@ -259,25 +232,7 @@ export default function Home() {
         </div>
       </section>
 
-      <footer className="py-10 px-6 border-t border-neutral-900">
-        <div className="max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
-          <span className="text-neutral-600 text-sm">MIT License</span>
-          <div className="flex items-center gap-6 text-sm text-neutral-500">
-            <a href="https://docs.forcecalendar.org" className="hover:text-white transition-colors">
-              Docs
-            </a>
-            <a href="https://github.com/forcecalendar" className="hover:text-white transition-colors">
-              GitHub
-            </a>
-            <a href="https://www.npmjs.com/org/forcecalendar" className="hover:text-white transition-colors">
-              npm
-            </a>
-            <Link href="/playground" className="hover:text-white transition-colors">
-              Playground
-            </Link>
-          </div>
-        </div>
-      </footer>
+      <Footer />
     </div>
   );
 }

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
+import Nav from "../components/Nav";
+import Footer from "../components/Footer";
 
 export default function PlaygroundPage() {
   const [isLoaded, setIsLoaded] = useState(false);
@@ -46,28 +48,7 @@ export default function PlaygroundPage() {
 
   return (
     <div className="min-h-screen bg-black">
-      {/* Nav */}
-      <nav className="fixed top-0 w-full z-50 bg-black/80 backdrop-blur-xl border-b border-neutral-900">
-        <div className="max-w-5xl mx-auto px-6 h-14 flex items-center justify-between">
-          <Link href="/" className="text-lg font-medium text-white">
-            <span className="italic">force</span>Calendar
-          </Link>
-          <div className="flex items-center gap-6">
-            <a
-              href="https://docs.forcecalendar.org"
-              className="text-sm text-neutral-400 hover:text-white transition-colors"
-            >
-              Docs
-            </a>
-            <a
-              href="https://github.com/forcecalendar"
-              className="text-sm text-neutral-400 hover:text-white transition-colors"
-            >
-              GitHub
-            </a>
-          </div>
-        </div>
-      </nav>
+      <Nav cta="none" />
 
       {/* Hero */}
       <section className="pt-28 pb-8 px-6">
@@ -212,17 +193,7 @@ export default function PlaygroundPage() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="py-10 px-6 border-t border-neutral-900">
-        <div className="max-w-5xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
-          <span className="text-neutral-600 text-sm">MIT License</span>
-          <div className="flex items-center gap-6 text-sm text-neutral-500">
-            <a href="https://docs.forcecalendar.org" className="hover:text-white transition-colors">Docs</a>
-            <Link href="/" className="hover:text-white transition-colors">Home</Link>
-            <a href="https://github.com/forcecalendar" className="hover:text-white transition-colors">GitHub</a>
-          </div>
-        </div>
-      </footer>
+      <Footer />
 
       {/* Styles for the web component */}
       <style jsx global>{`


### PR DESCRIPTION
## Summary
- Created `app/components/Nav.tsx` and `app/components/Footer.tsx`
- Replaced duplicated nav/footer markup across all 5 pages (home, core, interface, playground, not-found)
- Nav accepts a `cta` prop to control the CTA button visibility
- Single source of truth for navigation links and footer content

## Test plan
- [ ] Verify navigation renders on all pages with correct links
- [ ] Verify footer renders consistently on all pages
- [ ] Verify playground page hides the CTA button (cta="none")