### PR TITLE
Fix playground CSS variables to match interface package tokens

### DIFF
--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -234,12 +234,16 @@ export default function PlaygroundPage() {
           display: block;
           width: 100%;
           min-height: 500px;
-          --fc-bg-primary: #0a0a0a;
-          --fc-bg-secondary: #171717;
-          --fc-border-color: #262626;
-          --fc-text-primary: #ffffff;
+          --fc-background: #0a0a0a;
+          --fc-background-alt: #171717;
+          --fc-background-hover: #262626;
+          --fc-border-color: #333333;
+          --fc-text-color: #ffffff;
           --fc-text-secondary: #a3a3a3;
-          --fc-accent-color: #14b8a6;
+          --fc-text-light: #737373;
+          --fc-primary-color: #14b8a6;
+          --fc-primary-hover: #0d9488;
+          --fc-danger-color: #ef4444;
         }
       `}</style>
     </div>


### PR DESCRIPTION
## Summary
- Replaced non-existent CSS custom properties (`--fc-bg-primary`, `--fc-text-primary`, etc.) with actual tokens from `@forcecalendar/interface`
- The calendar in the playground will now render with the intended dark theme instead of default light theme
- Correct tokens: `--fc-background`, `--fc-text-color`, `--fc-primary-color`, `--fc-border-color`, etc.

## Test plan
- [ ] Open playground and verify the calendar renders with dark background
- [ ] Verify text is white/light against the dark background
- [ ] Verify the teal accent color applies to today indicator and primary elements