### PR TITLE
Improve calendar loading UX and fix production build

### DIFF
--- a/app/components/CalendarLoader.tsx
+++ b/app/components/CalendarLoader.tsx
@@ -70,8 +70,45 @@ export default function CalendarLoader({
 
   if (status === "loading") {
     return (
-      <div className="flex items-center justify-center" style={{ minHeight: height }}>
-        <div className="inline-block w-6 h-6 border-2 border-brand-500 border-t-transparent rounded-full animate-spin" />
+      <div className="p-4" style={{ minHeight: height }}>
+        {/* Skeleton header */}
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-2">
+            <div className="w-20 h-7 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+            <div className="w-6 h-7 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-7 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+            <div className="w-16 h-7 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+            <div className="w-8 h-7 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+          </div>
+          <div className="flex items-center gap-1">
+            <div className="w-16 h-7 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+            <div className="w-12 h-7 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+            <div className="w-12 h-7 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+            <div className="w-12 h-7 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+          </div>
+        </div>
+        {/* Skeleton grid matching the active view to reduce layout shift */}
+        <div className={`grid ${view === "day" ? "grid-cols-1" : "grid-cols-7"} gap-px bg-slate-200 dark:bg-slate-700 border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden`}>
+          {Array.from({ length: view === "month" ? 35 : view === "week" ? 7 : 1 }).map((_, i) => (
+            <div
+              key={i}
+              className="bg-white dark:bg-slate-900 p-2"
+              style={{ minHeight: view === "month" ? height / 6 : height }}
+            >
+              {view === "month" && (
+                <>
+                  <div className="w-6 h-5 bg-slate-200 dark:bg-slate-700 rounded animate-pulse mb-2" />
+                  <div className="space-y-1">
+                    <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                    <div className="h-4 bg-slate-200 dark:bg-slate-700 rounded animate-pulse" />
+                  </div>
+                </>
+              )}
+            </div>
+          ))}
+        </div>
       </div>
     );
   }

--- a/app/interface/InterfacePreview.tsx
+++ b/app/interface/InterfacePreview.tsx
@@ -1,12 +1,21 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import CalendarLoader from "../components/CalendarLoader";
 
 const views = ["month", "week", "day"] as const;
 
 export default function InterfacePreview() {
   const [calendarView, setCalendarView] = useState<string>("month");
+  const [displayView, setDisplayView] = useState<string>("month");
+  const isTransitioning = calendarView !== displayView;
+
+  useEffect(() => {
+    if (calendarView !== displayView) {
+      const timer = setTimeout(() => setDisplayView(calendarView), 150);
+      return () => clearTimeout(timer);
+    }
+  }, [calendarView, displayView]);
 
   return (
     <div className="rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden bg-white dark:bg-slate-900/50">
@@ -17,10 +26,11 @@ export default function InterfacePreview() {
             <button
               key={v}
               onClick={() => setCalendarView(v)}
+              disabled={isTransitioning}
               className={`px-3 py-1 text-xs capitalize transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-950 ${
                 calendarView === v
                   ? "bg-cyan-600 text-white"
-                  : "text-slate-500 hover:text-slate-900 dark:hover:text-white"
+                  : "text-slate-500 hover:text-slate-900 dark:hover:text-white disabled:opacity-50 disabled:cursor-not-allowed"
               }`}
             >
               {v}
@@ -28,9 +38,14 @@ export default function InterfacePreview() {
           ))}
         </div>
       </div>
-      <div className="p-2">
+      <div className="p-2 relative">
+        {isTransitioning && (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/80 dark:bg-slate-900/80 backdrop-blur-sm">
+            <div className="w-6 h-6 border-2 border-brand-500 border-t-transparent rounded-full animate-spin" />
+          </div>
+        )}
         <CalendarLoader
-          view={calendarView}
+          view={displayView}
           height={420}
           cssVars={{
             "fc-background": "var(--preview-bg, #ffffff)",
@@ -42,7 +57,7 @@ export default function InterfacePreview() {
       </div>
       <div className="px-4 py-3 border-t border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900">
         <code className="text-xs text-slate-500 font-mono">
-          &lt;forcecal-main view=&quot;{calendarView}&quot; locale=&quot;en-US&quot; /&gt;
+          &lt;forcecal-main view=&quot;{displayView}&quot; locale=&quot;en-US&quot; /&gt;
         </code>
       </div>
     </div>

--- a/app/playground/PlaygroundClient.tsx
+++ b/app/playground/PlaygroundClient.tsx
@@ -176,7 +176,7 @@ export default function PlaygroundClient() {
           {eventList.length > 0 && (
             <ul className="space-y-1.5">
               {eventList.map((e) => (
-                <li key={e.id} className="text-xs text-slate-500 dark:text-slate-400 font-mono truncate">
+                <li key={String(e.id)} className="text-xs text-slate-500 dark:text-slate-400 font-mono truncate">
                   {String(e.title || e.id)}
                 </li>
               ))}


### PR DESCRIPTION
## Summary
- **CalendarLoader**: replaces the loading spinner with a skeleton that mirrors the calendar grid (header chrome + 35/7/1 cells depending on view) — better perceived performance and less layout shift when the web component mounts. Ported from the orphaned `fix/ui-remaining-issues` branch and adapted: skeleton uses `grid-cols-1` for day view, and the transition state is derived (`calendarView \!== displayView`) instead of stored, satisfying `react-hooks/set-state-in-effect`.
- **InterfacePreview**: view-switch buttons disable during a 150ms transition overlay, preventing rapid-click race conditions while the custom element re-renders.
- **PlaygroundClient**: `key={String(e.id)}` — `e.id` is `unknown` (`Record<string, unknown>[]`), which fails `next build` type checking. **Master is currently unbuildable because of this**; verified by building a clean checkout.

## Test plan
- `npm run build` passes (was failing on master).
- `npm run lint`: no new issues (one pre-existing `react-hooks/set-state-in-effect` error in ThemeProvider.tsx remains on master, untouched here).

Supersedes the local-only `fix/ui-remaining-issues` branch (d332954); its MobileMenu/ThemeProvider portions were already superseded by #62.