### PR TITLE
Bump @forcecalendar packages to published versions, fix theme lint

### DIFF
--- a/app/components/ThemeProvider.tsx
+++ b/app/components/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, useEffect, useCallback, useState } from "react";
+import { createContext, useContext, useEffect, useCallback, useState, useSyncExternalStore } from "react";
 
 type Theme = "light" | "dark";
 
@@ -33,6 +33,8 @@ function getInitialTheme(): Theme {
   return "light";
 }
 
+const emptySubscribe = () => () => {};
+
 export function ThemeProvider({
   children,
   initialTheme,
@@ -41,16 +43,25 @@ export function ThemeProvider({
   initialTheme: Theme;
 }) {
   const [theme, setTheme] = useState<Theme>(initialTheme);
-  const [isMounted, setIsMounted] = useState(false);
+  // Hydration-safe mounted flag without setState-in-effect: false during SSR
+  // and the hydration pass, true on the client afterwards
+  const isMounted = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  );
 
-  // After hydration, use the correct theme from localStorage or system preference
+  // After hydration, use the correct theme from localStorage or system
+  // preference; deferred a tick so the hydration pass isn't invalidated
   useEffect(() => {
-    setIsMounted(true);
-    const correctTheme = getInitialTheme();
-    if (correctTheme !== initialTheme) {
-      setTheme(correctTheme);
-    }
-  }, [initialTheme]);
+    const timer = setTimeout(() => {
+      setTheme((prev) => {
+        const correctTheme = getInitialTheme();
+        return correctTheme !== prev ? correctTheme : prev;
+      });
+    }, 0);
+    return () => clearTimeout(timer);
+  }, []);
 
   useEffect(() => {
     if (!isMounted) return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -459,16 +459,16 @@
       }
     },
     "node_modules/@forcecalendar/core": {
-      "version": "2.1.54",
-      "resolved": "https://registry.npmjs.org/@forcecalendar/core/-/core-2.1.54.tgz",
-      "integrity": "sha512-ilVLpuS3u9hb0qemKhvgE9jtBTMPe7Q1+Ug9lte2BG/yAjD5brbd5M3UZc2mol/OHEO1FDXk38YHtDrqkxSv4Q==",
+      "version": "2.1.57",
+      "resolved": "https://registry.npmjs.org/@forcecalendar/core/-/core-2.1.57.tgz",
+      "integrity": "sha512-jQYGakQX3Ch3JGispT9sOdJTWqQPQnP9pjM5nNLomnX+S9JTTJdjKjCmTMCfIDuLr1YYHRyh5eBRUKhvENKQQg==",
       "license": "MIT",
       "peer": true
     },
     "node_modules/@forcecalendar/interface": {
-      "version": "1.0.58",
-      "resolved": "https://registry.npmjs.org/@forcecalendar/interface/-/interface-1.0.58.tgz",
-      "integrity": "sha512-7HFoHVxEjelHOFWEpSOfjcfRFslsGB16TtbJswmj20pJRNgQCSlcieVyNhaM+0ctGPinIh0valOCs7ByRWaj1Q==",
+      "version": "1.0.59",
+      "resolved": "https://registry.npmjs.org/@forcecalendar/interface/-/interface-1.0.59.tgz",
+      "integrity": "sha512-KVfFRzoNMJPyNmRvDiWph3kND7Pe3ytdY8MKF0OMJXBhkYT4C2SLqWl5+dTJb4r0NdB8Vm2ZI4oRkWLufvFq1Q==",
       "license": "MIT",
       "peerDependencies": {
         "@forcecalendar/core": ">=2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@forcecalendar/core": "^2.1.1",
-        "@forcecalendar/interface": "^1.0.57",
+        "@forcecalendar/core": "^2.1.54",
+        "@forcecalendar/interface": "^1.0.58",
         "next": "16.1.6",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -71,6 +71,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -458,15 +459,16 @@
       }
     },
     "node_modules/@forcecalendar/core": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/@forcecalendar/core/-/core-2.1.20.tgz",
-      "integrity": "sha512-rgIq4y/iAQ0bkiByoHUsbZql34MDhaDt/oyJVUq2CduBp+R6CoveqLd7k3ET6hm4h+H1+FTUxWjqY1ptgkPeSQ==",
-      "license": "MIT"
+      "version": "2.1.54",
+      "resolved": "https://registry.npmjs.org/@forcecalendar/core/-/core-2.1.54.tgz",
+      "integrity": "sha512-ilVLpuS3u9hb0qemKhvgE9jtBTMPe7Q1+Ug9lte2BG/yAjD5brbd5M3UZc2mol/OHEO1FDXk38YHtDrqkxSv4Q==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@forcecalendar/interface": {
-      "version": "1.0.57",
-      "resolved": "https://registry.npmjs.org/@forcecalendar/interface/-/interface-1.0.57.tgz",
-      "integrity": "sha512-+OzJe1HqjLHW/MwRt6g6woE7H6nibmRfEdDsIIS6eP4KPgPg4QpfcijKWb/VheYhVpuoJ3mGb1ud8MgoS5h6Cw==",
+      "version": "1.0.58",
+      "resolved": "https://registry.npmjs.org/@forcecalendar/interface/-/interface-1.0.58.tgz",
+      "integrity": "sha512-7HFoHVxEjelHOFWEpSOfjcfRFslsGB16TtbJswmj20pJRNgQCSlcieVyNhaM+0ctGPinIh0valOCs7ByRWaj1Q==",
       "license": "MIT",
       "peerDependencies": {
         "@forcecalendar/core": ">=2.0.0"
@@ -1309,6 +1311,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1368,6 +1371,7 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -1880,6 +1884,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2298,6 +2303,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2936,6 +2942,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3121,6 +3128,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4346,6 +4354,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -5087,6 +5096,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5288,6 +5298,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5297,6 +5308,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6101,6 +6113,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6270,6 +6283,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6552,6 +6566,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "lint": "eslint"
   },
   "dependencies": {
-    "@forcecalendar/core": "^2.1.1",
-    "@forcecalendar/interface": "^1.0.57",
+    "@forcecalendar/core": "^2.1.54",
+    "@forcecalendar/interface": "^1.0.58",
     "next": "16.1.6",
     "react": "19.2.4",
     "react-dom": "19.2.4"


### PR DESCRIPTION
## Summary
- Bumps `@forcecalendar/core` → ^2.1.54 and `@forcecalendar/interface` → ^1.0.58, the versions published to npm today, so the site demos run on what we ship.
- Fixes the last remaining lint error on master: ThemeProvider now derives its hydration flag via `useSyncExternalStore` (no setState-in-effect) and defers the localStorage/system-preference theme correction one tick. Behavior unchanged: SSR renders the cookie theme, client corrects after hydration.

## Test plan
- `npm run lint`: **0 errors** (master previously failed).
- `npm run build`: passes, all 10 pages generate.

Supersedes #57 (stale Dependabot bump to core 2.1.25).