### PR TITLE
Refresh entire site UI within the existing design system

### DIFF
--- a/app/components/CodeBlock.tsx
+++ b/app/components/CodeBlock.tsx
@@ -6,16 +6,23 @@ interface CodeBlockProps {
 
 export default function CodeBlock({ code, filename, language }: CodeBlockProps) {
   return (
-    <div className="rounded-lg border border-slate-800 overflow-hidden bg-slate-950">
+    <div className="rounded-xl overflow-hidden bg-slate-950 ring-1 ring-slate-800 shadow-xl shadow-slate-200/50 dark:shadow-slate-950/50">
       {filename && (
-        <div className="px-4 py-2.5 border-b border-slate-800 flex items-center justify-between">
-          <span className="text-xs text-slate-500">{filename}</span>
+        <div className="px-4 py-3 border-b border-slate-800/80 flex items-center gap-3 bg-slate-900/60">
+          <span className="flex items-center gap-1.5" aria-hidden>
+            <span className="w-2.5 h-2.5 rounded-full bg-slate-700" />
+            <span className="w-2.5 h-2.5 rounded-full bg-slate-700" />
+            <span className="w-2.5 h-2.5 rounded-full bg-slate-700" />
+          </span>
+          <span className="text-xs font-mono text-slate-400">{filename}</span>
           {language && (
-            <span className="text-xs font-mono text-slate-600">{language}</span>
+            <span className="ml-auto text-[10px] font-mono uppercase tracking-wider text-slate-600">
+              {language}
+            </span>
           )}
         </div>
       )}
-      <pre className="p-4 text-sm font-mono text-slate-300 overflow-x-auto leading-relaxed">
+      <pre className="p-5 text-sm font-mono text-slate-300 overflow-x-auto leading-relaxed">
         <code>{code}</code>
       </pre>
     </div>

--- a/app/components/FeatureCard.tsx
+++ b/app/components/FeatureCard.tsx
@@ -6,11 +6,11 @@ interface FeatureCardProps {
 
 export default function FeatureCard({ icon, title, description }: FeatureCardProps) {
   return (
-    <div className="p-5 rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50">
-      <div className="w-10 h-10 rounded-lg bg-brand-50 dark:bg-brand-500/10 text-brand-600 dark:text-brand-400 flex items-center justify-center mb-3">
+    <div className="group relative p-6 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50 transition-all duration-200 hover:border-brand-300 dark:hover:border-brand-500/40 hover:shadow-lg hover:shadow-slate-200/60 dark:hover:shadow-slate-950/60 hover:-translate-y-0.5">
+      <div className="w-10 h-10 rounded-lg bg-brand-50 dark:bg-brand-500/10 ring-1 ring-brand-100 dark:ring-brand-500/20 text-brand-600 dark:text-brand-400 flex items-center justify-center mb-4 transition-colors group-hover:bg-brand-100 dark:group-hover:bg-brand-500/20">
         {icon}
       </div>
-      <h3 className="font-medium text-slate-900 dark:text-white mb-1">{title}</h3>
+      <h3 className="font-medium text-slate-900 dark:text-white mb-1.5">{title}</h3>
       <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed">{description}</p>
     </div>
   );

--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -56,15 +56,15 @@ function FooterColumn({
 
 export default function Footer() {
   return (
-    <footer className="border-t border-slate-200 dark:border-slate-800">
-      <div className="max-w-5xl mx-auto px-6 py-12">
+    <footer className="border-t border-slate-200 dark:border-slate-800 bg-slate-50/50 dark:bg-slate-900/20">
+      <div className="max-w-6xl mx-auto px-6 py-16">
         <div className="grid grid-cols-2 md:grid-cols-4 gap-8">
           <div className="col-span-2 md:col-span-1">
             <div className="text-lg tracking-tight text-slate-900 dark:text-white mb-2">
               <span className="font-light">force</span>
               <span className="font-semibold">Calendar</span>
             </div>
-            <p className="text-sm text-slate-500 dark:text-slate-400">
+            <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed">
               Calendar infrastructure for strict enterprise environments.
             </p>
           </div>
@@ -72,8 +72,8 @@ export default function Footer() {
           <FooterColumn title="Resources" links={resourceLinks} />
           <FooterColumn title="Community" links={communityLinks} />
         </div>
-        <div className="mt-10 pt-6 border-t border-slate-200 dark:border-slate-800 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-slate-400 dark:text-slate-500">
+        <div className="mt-12 pt-8 border-t border-slate-200 dark:border-slate-800 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500 dark:text-slate-400 [&>span]:inline-flex [&>span]:items-center [&>span]:gap-1.5 [&>span]:px-2.5 [&>span]:py-1 [&>span]:rounded-full [&>span]:ring-1 [&>span]:ring-slate-200 dark:[&>span]:ring-slate-800 [&>span]:bg-white dark:[&>span]:bg-slate-900">
             <span className="inline-flex items-center gap-1.5">
               <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" /></svg>
               Zero Dependencies

--- a/app/components/InstallCommand.tsx
+++ b/app/components/InstallCommand.tsx
@@ -18,17 +18,20 @@ export default function InstallCommand({ command }: { command: string }) {
   return (
     <button
       onClick={handleCopy}
-      className="group inline-flex items-center gap-3 px-4 py-2.5 bg-slate-100 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg text-sm font-mono text-slate-600 dark:text-slate-300 hover:border-slate-300 dark:hover:border-slate-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-950"
+      aria-label={`Copy install command: ${command}`}
+      className="group inline-flex items-center gap-3 pl-4 pr-3 py-3 bg-slate-50 dark:bg-slate-900 ring-1 ring-slate-200 dark:ring-slate-800 rounded-xl text-sm font-mono text-slate-700 dark:text-slate-300 shadow-sm transition-all hover:ring-slate-300 dark:hover:ring-slate-700 hover:shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-slate-950"
     >
-      <span className="text-slate-400">$</span>
-      <span>{command}</span>
-      <span className="text-slate-400 group-hover:text-slate-600 dark:group-hover:text-slate-200 transition-colors">
+      <span className="text-brand-500 dark:text-brand-400 select-none" aria-hidden>
+        $
+      </span>
+      <span className="text-left">{command}</span>
+      <span className="flex items-center justify-center w-7 h-7 rounded-lg bg-white dark:bg-slate-800 ring-1 ring-slate-200 dark:ring-slate-700 text-slate-400 group-hover:text-slate-600 dark:group-hover:text-slate-200 transition-colors">
         {copied ? (
-          <svg className="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-3.5 h-3.5 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
           </svg>
         ) : (
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
           </svg>
         )}

--- a/app/components/Nav.tsx
+++ b/app/components/Nav.tsx
@@ -44,8 +44,8 @@ export default function Nav() {
 
   return (
     <>
-      <nav className="sticky top-0 z-30 w-full bg-white/80 dark:bg-slate-950/80 backdrop-blur-md border-b border-slate-200 dark:border-slate-800">
-        <div className="max-w-5xl mx-auto px-6 h-14 flex items-center justify-between">
+      <nav className="sticky top-0 z-30 w-full bg-white/75 dark:bg-slate-950/75 backdrop-blur-xl border-b border-slate-200/80 dark:border-slate-800/80">
+        <div className="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between">
 
           {/* Left: Logo + site switcher */}
           <div className="flex items-center gap-3">
@@ -107,15 +107,15 @@ export default function Nav() {
           </div>
 
           {/* Center: page-level links */}
-          <div className="hidden md:flex items-center gap-6 text-sm">
+          <div className="hidden md:flex items-center gap-1 text-sm">
             {pageLinks.map((link) => (
               <Link
                 key={link.href}
                 href={link.href}
-                className={`transition-colors ${
+                className={`px-3 py-1.5 rounded-full transition-colors ${
                   isCurrentPage(link.href)
-                    ? "text-slate-900 dark:text-white font-medium"
-                    : "text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white"
+                    ? "text-slate-900 dark:text-white font-medium bg-slate-100 dark:bg-slate-800/80"
+                    : "text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-white hover:bg-slate-50 dark:hover:bg-slate-900"
                 }`}
               >
                 {link.label}

--- a/app/components/PackageCard.tsx
+++ b/app/components/PackageCard.tsx
@@ -18,17 +18,22 @@ export default function PackageCard({
   return (
     <Link
       href={href}
-      className="group block p-6 rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50 hover:border-slate-300 dark:hover:border-slate-700 transition-colors"
+      className="group relative block p-6 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50 transition-all duration-200 hover:border-slate-300 dark:hover:border-slate-700 hover:shadow-lg hover:shadow-slate-200/60 dark:hover:shadow-slate-950/60 hover:-translate-y-0.5"
     >
-      <div className={`text-xs font-mono uppercase tracking-wider mb-3 ${accentClass}`}>
+      <div className={`text-xs font-mono font-medium uppercase tracking-widest mb-3 ${accentClass}`}>
         {label}
       </div>
-      <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2">{name}</h3>
+      <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2 tracking-tight">
+        {name}
+      </h3>
       <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed mb-4">
         {description}
       </p>
-      <span className={`text-sm ${accentClass} group-hover:underline`}>
-        Learn more &rarr;
+      <span className={`inline-flex items-center gap-1 text-sm font-medium ${accentClass}`}>
+        Learn more
+        <span aria-hidden className="transition-transform duration-200 group-hover:translate-x-0.5">
+          &rarr;
+        </span>
       </span>
     </Link>
   );

--- a/app/components/SectionHeader.tsx
+++ b/app/components/SectionHeader.tsx
@@ -1,18 +1,35 @@
 interface SectionHeaderProps {
   title: string;
   subtitle?: string;
+  eyebrow?: string;
   id?: string;
+  align?: "left" | "center";
 }
 
-export default function SectionHeader({ title, subtitle, id }: SectionHeaderProps) {
+export default function SectionHeader({
+  title,
+  subtitle,
+  eyebrow,
+  id,
+  align = "left",
+}: SectionHeaderProps) {
+  const centered = align === "center";
   return (
-    <div className="mb-10">
+    <div className={`mb-12 ${centered ? "text-center" : ""}`}>
+      {eyebrow && (
+        <div className="mb-3 text-xs font-mono font-medium uppercase tracking-widest text-brand-600 dark:text-brand-400">
+          {eyebrow}
+        </div>
+      )}
       <h2
         id={id}
-        className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white scroll-mt-20"
+        className="text-2xl sm:text-3xl font-semibold tracking-tight text-slate-900 dark:text-white scroll-mt-24"
       >
         {id ? (
-          <a href={`#${id}`} className="hover:underline decoration-slate-300 dark:decoration-slate-700 underline-offset-4">
+          <a
+            href={`#${id}`}
+            className="hover:underline decoration-slate-300 dark:decoration-slate-700 underline-offset-8"
+          >
             {title}
           </a>
         ) : (
@@ -20,7 +37,13 @@ export default function SectionHeader({ title, subtitle, id }: SectionHeaderProp
         )}
       </h2>
       {subtitle && (
-        <p className="mt-2 text-slate-500 dark:text-slate-400">{subtitle}</p>
+        <p
+          className={`mt-3 text-slate-500 dark:text-slate-400 leading-relaxed ${
+            centered ? "max-w-2xl mx-auto" : "max-w-2xl"
+          }`}
+        >
+          {subtitle}
+        </p>
       )}
     </div>
   );

--- a/app/core/page.tsx
+++ b/app/core/page.tsx
@@ -34,39 +34,42 @@ export default function CorePage() {
       <Nav />
 
       {/* Hero */}
-      <section className="pt-24 pb-16 px-6">
-        <div className="max-w-3xl mx-auto">
-          <div className="text-xs font-mono text-violet-600 dark:text-violet-400 uppercase tracking-wider mb-4">
-            Core Engine
-          </div>
-          <h1 className="text-4xl sm:text-5xl font-semibold tracking-tight text-slate-900 dark:text-white mb-4">
-            @forcecalendar/core
-          </h1>
-          <p className="text-xl text-slate-500 dark:text-slate-400 mb-8">
-            Zero-dependency calendar logic for enterprise applications.
-          </p>
-          <div className="flex flex-wrap items-center gap-4">
-            <InstallCommand command="npm install @forcecalendar/core" />
-            <a
-              href="https://github.com/forcecalendar/core"
-              className="text-sm text-slate-500 hover:text-slate-900 dark:hover:text-white transition-colors"
-            >
-              View on GitHub &rarr;
-            </a>
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-grid" aria-hidden />
+        <div className="relative pt-24 pb-16 px-6">
+          <div className="max-w-4xl mx-auto">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-violet-50 dark:bg-violet-500/10 ring-1 ring-violet-200 dark:ring-violet-500/25 text-xs font-mono font-medium uppercase tracking-widest text-violet-600 dark:text-violet-400 mb-6">
+              Core Engine
+            </div>
+            <h1 className="text-4xl sm:text-5xl font-semibold tracking-tight text-slate-900 dark:text-white mb-4">
+              @forcecalendar/core
+            </h1>
+            <p className="text-xl text-slate-500 dark:text-slate-400 mb-8 max-w-2xl">
+              Zero-dependency calendar logic for enterprise applications.
+            </p>
+            <div className="flex flex-wrap items-center gap-4">
+              <InstallCommand command="npm install @forcecalendar/core" />
+              <a
+                href="https://github.com/forcecalendar/core"
+                className="inline-flex items-center gap-1 text-sm font-medium text-slate-500 hover:text-slate-900 dark:hover:text-white transition-colors"
+              >
+                View on GitHub <span aria-hidden>&rarr;</span>
+              </a>
+            </div>
           </div>
         </div>
       </section>
 
       {/* Metrics */}
-      <section className="py-16 px-6 border-t border-slate-200 dark:border-slate-800">
+      <section className="py-12 px-6 border-y border-slate-200 dark:border-slate-800 bg-slate-50/70 dark:bg-slate-900/30">
         <div className="max-w-4xl mx-auto">
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-5">
             {metrics.map((stat) => (
-              <div key={stat.label} className="text-center bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-lg p-4">
-                <div className="text-2xl font-semibold text-slate-900 dark:text-white">
+              <div key={stat.label} className="text-center bg-white dark:bg-slate-900/60 ring-1 ring-slate-200 dark:ring-slate-800 rounded-xl p-5">
+                <div className="text-2xl font-semibold tracking-tight text-slate-900 dark:text-white">
                   {stat.value}
                 </div>
-                <div className="text-xs text-slate-500 mt-1">{stat.label}</div>
+                <div className="text-xs text-slate-500 mt-1 uppercase tracking-wider">{stat.label}</div>
               </div>
             ))}
           </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,6 +8,39 @@ html {
   -moz-osx-font-smoothing: grayscale;
 }
 
+::selection {
+  background: rgb(37 99 235 / 0.15);
+}
+
+.dark ::selection {
+  background: rgb(96 165 250 / 0.25);
+}
+
+/* Subtle blueprint grid used behind heroes */
+.bg-grid {
+  background-image:
+    linear-gradient(to right, rgb(148 163 184 / 0.08) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(148 163 184 / 0.08) 1px, transparent 1px);
+  background-size: 32px 32px;
+  mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, black 30%, transparent 75%);
+  -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 0%, black 30%, transparent 75%);
+}
+
+.dark .bg-grid {
+  background-image:
+    linear-gradient(to right, rgb(148 163 184 / 0.06) 1px, transparent 1px),
+    linear-gradient(to bottom, rgb(148 163 184 / 0.06) 1px, transparent 1px);
+}
+
+/* Soft brand glow used behind heroes */
+.hero-glow {
+  background: radial-gradient(ellipse 50% 45% at 50% 0%, rgb(37 99 235 / 0.08), transparent 70%);
+}
+
+.dark .hero-glow {
+  background: radial-gradient(ellipse 50% 45% at 50% 0%, rgb(59 130 246 / 0.12), transparent 70%);
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/app/interface/page.tsx
+++ b/app/interface/page.tsx
@@ -101,31 +101,34 @@ export default function InterfacePage() {
       <Nav />
 
       {/* Hero */}
-      <section className="pt-24 pb-16 px-6">
-        <div className="max-w-3xl mx-auto">
-          <div className="text-xs font-mono text-cyan-600 dark:text-cyan-400 uppercase tracking-wider mb-4">
-            UI Components
-          </div>
-          <h1 className="text-4xl sm:text-5xl font-semibold tracking-tight text-slate-900 dark:text-white mb-4">
-            @forcecalendar/interface
-          </h1>
-          <p className="text-xl text-slate-500 dark:text-slate-400 mb-8">
-            Production-ready Web Components that work with any framework.
-          </p>
-          <div className="flex flex-wrap items-center gap-4">
-            <InstallCommand command="npm install @forcecalendar/interface" />
-            <Link
-              href="/playground"
-              className="text-sm text-cyan-600 dark:text-cyan-400 hover:underline"
-            >
-              Try Playground &rarr;
-            </Link>
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-grid" aria-hidden />
+        <div className="relative pt-24 pb-16 px-6">
+          <div className="max-w-4xl mx-auto">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-cyan-50 dark:bg-cyan-500/10 ring-1 ring-cyan-200 dark:ring-cyan-500/25 text-xs font-mono font-medium uppercase tracking-widest text-cyan-600 dark:text-cyan-400 mb-6">
+              UI Components
+            </div>
+            <h1 className="text-4xl sm:text-5xl font-semibold tracking-tight text-slate-900 dark:text-white mb-4">
+              @forcecalendar/interface
+            </h1>
+            <p className="text-xl text-slate-500 dark:text-slate-400 mb-8 max-w-2xl">
+              Production-ready Web Components that work with any framework.
+            </p>
+            <div className="flex flex-wrap items-center gap-4">
+              <InstallCommand command="npm install @forcecalendar/interface" />
+              <Link
+                href="/playground"
+                className="inline-flex items-center gap-1 text-sm font-medium text-cyan-600 dark:text-cyan-400 hover:underline"
+              >
+                Try Playground <span aria-hidden>&rarr;</span>
+              </Link>
+            </div>
           </div>
         </div>
       </section>
 
       {/* Live Preview */}
-      <section className="py-12 px-6 border-t border-slate-200 dark:border-slate-800">
+      <section className="py-12 px-6 border-t border-slate-200 dark:border-slate-800 bg-slate-50/70 dark:bg-slate-900/30">
         <div className="max-w-4xl mx-auto">
           <InterfacePreview />
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,6 +26,13 @@ const problems = [
   },
 ];
 
+const stats = [
+  { value: "0", label: "Runtime dependencies" },
+  { value: "2.9x", label: "Smaller than FullCalendar" },
+  { value: "35+", label: "CSS theming tokens" },
+  { value: "MIT", label: "Licensed, forever" },
+];
+
 const codeExample = `import { Calendar } from '@forcecalendar/core';
 import '@forcecalendar/interface';
 
@@ -99,63 +106,98 @@ export default function Home() {
       <Nav />
 
       {/* Hero */}
-      <section className="pt-24 pb-16 px-6">
-        <div className="max-w-3xl mx-auto text-center">
-          <h1 className="text-4xl sm:text-5xl font-semibold tracking-tight text-slate-900 dark:text-white leading-tight">
-            Calendar infrastructure for strict enterprise environments.
-          </h1>
-          <p className="mt-6 text-lg text-slate-500 dark:text-slate-400 max-w-2xl mx-auto">
-            Headless scheduling engine plus framework-agnostic Web Components.
-            Zero dependencies. Built for Salesforce Locker Service and strict CSP.
-          </p>
-          <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
-            <InstallCommand command="npm install @forcecalendar/core @forcecalendar/interface" />
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-grid" aria-hidden />
+        <div className="absolute inset-0 hero-glow" aria-hidden />
+        <div className="relative pt-28 pb-20 px-6">
+          <div className="max-w-3xl mx-auto text-center">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/80 dark:bg-slate-900/80 ring-1 ring-slate-200 dark:ring-slate-800 text-xs font-medium text-slate-600 dark:text-slate-300 shadow-sm backdrop-blur mb-8">
+              <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" aria-hidden />
+              Zero dependencies &middot; MIT licensed &middot; Locker Service safe
+            </div>
+            <h1 className="text-4xl sm:text-6xl font-semibold tracking-tight text-slate-900 dark:text-white leading-[1.1]">
+              Calendar infrastructure for{" "}
+              <span className="text-transparent bg-clip-text bg-gradient-to-r from-brand-600 via-brand-500 to-cyan-500 dark:from-brand-400 dark:via-brand-300 dark:to-cyan-400">
+                strict enterprise
+              </span>{" "}
+              environments.
+            </h1>
+            <p className="mt-6 text-lg sm:text-xl text-slate-500 dark:text-slate-400 max-w-2xl mx-auto leading-relaxed">
+              Headless scheduling engine plus framework-agnostic Web Components.
+              Built for Salesforce Locker Service and strict CSP.
+            </p>
+            <div className="mt-10 flex flex-col sm:flex-row items-center justify-center gap-3">
+              <InstallCommand command="npm install @forcecalendar/core @forcecalendar/interface" />
+            </div>
+            <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+              <Link
+                href="/salesforce"
+                className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#00A1E0] text-white text-sm font-medium rounded-lg shadow-sm shadow-[#00A1E0]/25 hover:bg-[#0082B4] hover:shadow-md transition-all"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M10.05 4.2a4.83 4.83 0 0 1 3.57 1.59 3.86 3.86 0 0 1 5.4.44 3.86 3.86 0 0 1 1.87 6.64 4.34 4.34 0 0 1-3.37 5.13H7.38a5.28 5.28 0 0 1-4.16-2.07A5.28 5.28 0 0 1 5.6 7.2a4.83 4.83 0 0 1 4.45-3z" /></svg>
+                Install on Salesforce
+              </Link>
+              <a
+                href="https://github.com/forcecalendar"
+                className="inline-flex items-center gap-2 px-5 py-2.5 bg-slate-900 dark:bg-white text-white dark:text-slate-900 text-sm font-medium rounded-lg shadow-sm hover:bg-slate-800 dark:hover:bg-slate-100 hover:shadow-md transition-all"
+              >
+                GitHub
+              </a>
+              <a
+                href="https://docs.forcecalendar.org"
+                className="inline-flex items-center px-5 py-2.5 ring-1 ring-slate-300 dark:ring-slate-700 text-slate-700 dark:text-slate-300 text-sm font-medium rounded-lg bg-white/60 dark:bg-slate-900/60 backdrop-blur hover:bg-slate-50 dark:hover:bg-slate-900 transition-colors"
+              >
+                Documentation
+              </a>
+            </div>
           </div>
-          <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
-            <Link
-              href="/salesforce"
-              className="inline-flex items-center gap-2 px-5 py-2.5 bg-[#00A1E0] text-white text-sm font-medium rounded-lg hover:bg-[#0082B4] transition-colors"
-            >
-              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M10.05 4.2a4.83 4.83 0 0 1 3.57 1.59 3.86 3.86 0 0 1 5.4.44 3.86 3.86 0 0 1 1.87 6.64 4.34 4.34 0 0 1-3.37 5.13H7.38a5.28 5.28 0 0 1-4.16-2.07A5.28 5.28 0 0 1 5.6 7.2a4.83 4.83 0 0 1 4.45-3z" /></svg>
-              Install on Salesforce
-            </Link>
-            <a
-              href="https://github.com/forcecalendar"
-              className="inline-flex items-center gap-2 px-5 py-2.5 bg-slate-900 dark:bg-white text-white dark:text-slate-900 text-sm font-medium rounded-lg hover:bg-slate-800 dark:hover:bg-slate-100 transition-colors"
-            >
-              GitHub
-            </a>
-            <a
-              href="https://docs.forcecalendar.org"
-              className="inline-flex items-center px-5 py-2.5 border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-300 text-sm font-medium rounded-lg hover:bg-slate-50 dark:hover:bg-slate-900 transition-colors"
-            >
-              Documentation
-            </a>
+        </div>
+
+        {/* Stats strip */}
+        <div className="relative border-y border-slate-200 dark:border-slate-800 bg-white/60 dark:bg-slate-900/40 backdrop-blur">
+          <div className="max-w-5xl mx-auto px-6 py-8 grid grid-cols-2 lg:grid-cols-4 gap-8">
+            {stats.map((stat) => (
+              <div key={stat.label} className="text-center">
+                <div className="text-3xl font-semibold tracking-tight text-slate-900 dark:text-white">
+                  {stat.value}
+                </div>
+                <div className="mt-1 text-xs text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+                  {stat.label}
+                </div>
+              </div>
+            ))}
           </div>
         </div>
       </section>
 
-
       {/* The Problem */}
-      <section className="py-20 px-6 border-t border-slate-200 dark:border-slate-800">
+      <section className="py-24 px-6">
         <div className="max-w-5xl mx-auto">
           <SectionHeader
+            eyebrow="Why forceCalendar"
             title="The problem with calendar libraries in enterprise"
             id="why"
           />
-          <div className="grid md:grid-cols-3 gap-6">
-            {problems.map((item) => (
+          <div className="grid md:grid-cols-3 gap-5">
+            {problems.map((item, i) => (
               <div
                 key={item.title}
-                className="p-6 rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50"
+                className="relative p-6 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50"
               >
+                <div className="text-xs font-mono text-slate-400 dark:text-slate-600 mb-3">
+                  0{i + 1}
+                </div>
                 <h3 className="font-medium text-slate-900 dark:text-white mb-3">
                   {item.title}
                 </h3>
-                <p className="text-sm text-slate-500 dark:text-slate-400 mb-4 leading-relaxed">
-                  {item.problem}
-                </p>
-                <div className="border-t border-slate-100 dark:border-slate-800 pt-4">
+                <div className="flex gap-2.5 mb-4">
+                  <span className="mt-1.5 flex-shrink-0 w-1.5 h-1.5 rounded-full bg-rose-400 dark:bg-rose-500" aria-hidden />
+                  <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed">
+                    {item.problem}
+                  </p>
+                </div>
+                <div className="flex gap-2.5 border-t border-slate-100 dark:border-slate-800 pt-4">
+                  <span className="mt-1.5 flex-shrink-0 w-1.5 h-1.5 rounded-full bg-emerald-500" aria-hidden />
                   <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">
                     {item.solution}
                   </p>
@@ -167,14 +209,15 @@ export default function Home() {
       </section>
 
       {/* Salesforce Showcase */}
-      <section className="py-20 px-6 border-t border-slate-200 dark:border-slate-800">
+      <section className="py-24 px-6 bg-slate-50/70 dark:bg-slate-900/30 border-y border-slate-200 dark:border-slate-800">
         <div className="max-w-5xl mx-auto">
           <SectionHeader
+            eyebrow="Flagship integration"
             title="Started with Salesforce"
             subtitle="Most calendar libraries break inside Locker Service — that's where forceCalendar started. The same zero-dependency architecture works in any strict enterprise environment."
             id="salesforce"
           />
-          <div className="rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden bg-white dark:bg-slate-900/50 shadow-sm">
+          <div className="rounded-2xl border border-slate-200 dark:border-slate-800 overflow-hidden bg-white dark:bg-slate-900/50 shadow-xl shadow-slate-200/50 dark:shadow-slate-950/50">
             <div className="relative">
               <Image
                 src="/salesforce-month.png"
@@ -214,8 +257,8 @@ export default function Home() {
               </div>
             </div>
           </div>
-          <div className="mt-6 grid grid-cols-2 gap-4">
-            <div className="rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden bg-white dark:bg-slate-900/50 shadow-sm">
+          <div className="mt-5 grid grid-cols-2 gap-5">
+            <div className="rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden bg-white dark:bg-slate-900/50 shadow-sm transition-shadow hover:shadow-lg hover:shadow-slate-200/60 dark:hover:shadow-slate-950/60">
               <Image
                 src="/salesforce-week.png"
                 alt="forceCalendar week view inside Salesforce showing timed events"
@@ -227,7 +270,7 @@ export default function Home() {
                 <p className="text-xs font-medium text-slate-500 dark:text-slate-400">Week view with timed events</p>
               </div>
             </div>
-            <div className="rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden bg-white dark:bg-slate-900/50 shadow-sm">
+            <div className="rounded-xl border border-slate-200 dark:border-slate-800 overflow-hidden bg-white dark:bg-slate-900/50 shadow-sm transition-shadow hover:shadow-lg hover:shadow-slate-200/60 dark:hover:shadow-slate-950/60">
               <Image
                 src="/salesforce-day.png"
                 alt="forceCalendar day view inside Salesforce showing detailed event blocks"
@@ -244,16 +287,17 @@ export default function Home() {
       </section>
 
       {/* Enterprise Platform */}
-      <section className="py-20 px-6 border-t border-slate-200 dark:border-slate-800">
+      <section className="py-24 px-6">
         <div className="max-w-5xl mx-auto">
           <SectionHeader
+            eyebrow="Where it runs"
             title="Enterprise calendar infrastructure"
             subtitle="Salesforce is the flagship integration. The same architecture works anywhere strict security is required."
             id="enterprise"
           />
-          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
-            <div className="p-5 rounded-lg border border-brand-200 dark:border-brand-800 bg-brand-50/50 dark:bg-brand-500/5">
-              <div className="w-8 h-8 rounded-lg bg-brand-100 dark:bg-brand-500/10 text-brand-600 dark:text-brand-400 flex items-center justify-center mb-3">
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-5">
+            <div className="p-5 rounded-xl border border-brand-200 dark:border-brand-500/30 bg-gradient-to-b from-brand-50/80 to-white dark:from-brand-500/10 dark:to-slate-900/50">
+              <div className="w-9 h-9 rounded-lg bg-brand-100 dark:bg-brand-500/15 ring-1 ring-brand-200 dark:ring-brand-500/25 text-brand-600 dark:text-brand-400 flex items-center justify-center mb-3">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
                 </svg>
@@ -261,8 +305,8 @@ export default function Home() {
               <h3 className="font-medium text-sm text-slate-900 dark:text-white mb-1">Salesforce</h3>
               <p className="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">Shipping now. LWC + Apex with full Locker Service compliance.</p>
             </div>
-            <div className="p-5 rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50">
-              <div className="w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-400 dark:text-slate-500 flex items-center justify-center mb-3">
+            <div className="p-5 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50">
+              <div className="w-9 h-9 rounded-lg bg-slate-100 dark:bg-slate-800 ring-1 ring-slate-200 dark:ring-slate-700 text-slate-500 dark:text-slate-400 flex items-center justify-center mb-3">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M12 21a9.004 9.004 0 008.716-6.747M12 21a9.004 9.004 0 01-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 017.843 4.582M12 3a8.997 8.997 0 00-7.843 4.582m15.686 0A11.953 11.953 0 0112 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0121 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0112 16.5a17.92 17.92 0 01-8.716-2.247m0 0A9.015 9.015 0 003 12c0-1.605.42-3.113 1.157-4.418" />
                 </svg>
@@ -270,8 +314,8 @@ export default function Home() {
               <h3 className="font-medium text-sm text-slate-900 dark:text-white mb-1">Any Web App</h3>
               <p className="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">Web Components work in React, Vue, Angular, or vanilla JS.</p>
             </div>
-            <div className="p-5 rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50">
-              <div className="w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-400 dark:text-slate-500 flex items-center justify-center mb-3">
+            <div className="p-5 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50">
+              <div className="w-9 h-9 rounded-lg bg-slate-100 dark:bg-slate-800 ring-1 ring-slate-200 dark:ring-slate-700 text-slate-500 dark:text-slate-400 flex items-center justify-center mb-3">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
                 </svg>
@@ -279,8 +323,8 @@ export default function Home() {
               <h3 className="font-medium text-sm text-slate-900 dark:text-white mb-1">Strict CSP</h3>
               <p className="text-xs text-slate-500 dark:text-slate-400 leading-relaxed">No eval, no inline styles. Works behind the strictest policies.</p>
             </div>
-            <div className="p-5 rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50">
-              <div className="w-8 h-8 rounded-lg bg-slate-100 dark:bg-slate-800 text-slate-400 dark:text-slate-500 flex items-center justify-center mb-3">
+            <div className="p-5 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50">
+              <div className="w-9 h-9 rounded-lg bg-slate-100 dark:bg-slate-800 ring-1 ring-slate-200 dark:ring-slate-700 text-slate-500 dark:text-slate-400 flex items-center justify-center mb-3">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M5.25 14.25h13.5m-13.5 0a3 3 0 01-3-3m3 3a3 3 0 100 6h13.5a3 3 0 100-6m-16.5-3a3 3 0 013-3h13.5a3 3 0 013 3m-19.5 0a4.5 4.5 0 01.9-2.7L5.737 5.1a3.375 3.375 0 012.7-1.35h7.126c1.062 0 2.062.5 2.7 1.35l2.587 3.45a4.5 4.5 0 01.9 2.7m0 0a3 3 0 01-3 3m0 3h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008zm-3 6h.008v.008h-.008v-.008zm0-6h.008v.008h-.008v-.008z" />
                 </svg>
@@ -293,21 +337,28 @@ export default function Home() {
       </section>
 
       {/* Architecture */}
-      <section className="py-20 px-6 border-t border-slate-200 dark:border-slate-800">
+      <section className="py-24 px-6 bg-slate-50/70 dark:bg-slate-900/30 border-y border-slate-200 dark:border-slate-800">
         <div className="max-w-5xl mx-auto">
           <SectionHeader
+            eyebrow="Architecture"
             title="Two packages, one architecture"
             subtitle="Use Core for scheduling logic and Interface for production-ready UI components."
             id="architecture"
           />
-          <div className="mb-10 inline-flex items-center px-4 py-2.5 rounded-lg bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 text-sm text-slate-600 dark:text-slate-400 font-mono">
-            @forcecalendar/core
-            <span className="mx-3 text-slate-300 dark:text-slate-600">&rarr;</span>
-            @forcecalendar/interface
-            <span className="mx-3 text-slate-300 dark:text-slate-600">&rarr;</span>
-            Salesforce LWC
+          <div className="mb-10 flex flex-wrap items-center gap-2 text-sm font-mono">
+            <span className="px-3 py-1.5 rounded-lg bg-white dark:bg-slate-900 ring-1 ring-slate-200 dark:ring-slate-800 text-violet-600 dark:text-violet-400">
+              @forcecalendar/core
+            </span>
+            <span className="text-slate-300 dark:text-slate-600" aria-hidden>&rarr;</span>
+            <span className="px-3 py-1.5 rounded-lg bg-white dark:bg-slate-900 ring-1 ring-slate-200 dark:ring-slate-800 text-cyan-600 dark:text-cyan-400">
+              @forcecalendar/interface
+            </span>
+            <span className="text-slate-300 dark:text-slate-600" aria-hidden>&rarr;</span>
+            <span className="px-3 py-1.5 rounded-lg bg-white dark:bg-slate-900 ring-1 ring-slate-200 dark:ring-slate-800 text-brand-600 dark:text-brand-400">
+              Salesforce LWC
+            </span>
           </div>
-          <div className="grid md:grid-cols-3 gap-6">
+          <div className="grid md:grid-cols-3 gap-5">
             <PackageCard
               href="/core"
               label="Core Engine"
@@ -322,16 +373,16 @@ export default function Home() {
               description="Web Components powered by Core. Framework-agnostic, Shadow DOM encapsulated. Works in React, Vue, Angular, or vanilla JS."
               accentClass="text-cyan-600 dark:text-cyan-400"
             />
-            <div className="block p-6 rounded-lg border border-brand-200 dark:border-brand-800 bg-brand-50/30 dark:bg-brand-500/5">
-              <div className="text-xs font-mono uppercase tracking-wider mb-3 text-brand-600 dark:text-brand-400">
+            <div className="relative block p-6 rounded-xl border border-brand-200 dark:border-brand-500/30 bg-gradient-to-b from-brand-50/80 to-white dark:from-brand-500/10 dark:to-slate-900/50">
+              <div className="text-xs font-mono font-medium uppercase tracking-widest mb-3 text-brand-600 dark:text-brand-400">
                 Salesforce Integration
               </div>
-              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2">Lightning Web Component</h3>
+              <h3 className="text-lg font-semibold text-slate-900 dark:text-white mb-2 tracking-tight">Lightning Web Component</h3>
               <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed mb-4">
                 Built on top of both packages. Loads as a static resource, connects to Salesforce data through Apex. Locker Service safe.
               </p>
-              <a href="#salesforce" className="text-sm text-brand-600 dark:text-brand-400 hover:underline">
-                See it running &rarr;
+              <a href="#salesforce" className="inline-flex items-center gap-1 text-sm font-medium text-brand-600 dark:text-brand-400 hover:underline">
+                See it running <span aria-hidden>&rarr;</span>
               </a>
             </div>
           </div>
@@ -339,9 +390,10 @@ export default function Home() {
       </section>
 
       {/* Code Example */}
-      <section className="py-20 px-6 border-t border-slate-200 dark:border-slate-800">
+      <section className="py-24 px-6">
         <div className="max-w-3xl mx-auto">
           <SectionHeader
+            eyebrow="Quick start"
             title="Five lines to a working calendar"
             id="code"
           />
@@ -350,10 +402,10 @@ export default function Home() {
       </section>
 
       {/* Feature Grid */}
-      <section className="py-20 px-6 border-t border-slate-200 dark:border-slate-800">
+      <section className="py-24 px-6 bg-slate-50/70 dark:bg-slate-900/30 border-y border-slate-200 dark:border-slate-800">
         <div className="max-w-5xl mx-auto">
-          <SectionHeader title="What&rsquo;s included" id="features" />
-          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          <SectionHeader eyebrow="Capabilities" title="What&rsquo;s included" id="features" />
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-5">
             {features.map((feature) => (
               <FeatureCard
                 key={feature.title}
@@ -366,43 +418,43 @@ export default function Home() {
         </div>
       </section>
 
-
       {/* Benchmark Highlights */}
-      <section className="py-20 px-6 border-t border-slate-200 dark:border-slate-800">
+      <section className="py-24 px-6">
         <div className="max-w-5xl mx-auto">
           <SectionHeader
+            eyebrow="Honest numbers"
             title="How it compares"
             subtitle="Independent benchmarks against FullCalendar — an excellent, widely-used library. forceCalendar exists for a different niche: strict enterprise environments where most calendar libraries cannot run."
             id="benchmarks"
           />
-          <div className="grid md:grid-cols-2 gap-6">
+          <div className="grid md:grid-cols-2 gap-5">
             {/* Bundle Size */}
-            <div className="p-6 rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50">
-              <div className="flex items-center gap-3 mb-4">
-                <div className="w-8 h-8 rounded-lg bg-emerald-100 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 flex items-center justify-center">
+            <div className="p-6 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50">
+              <div className="flex items-center gap-3 mb-5">
+                <div className="w-9 h-9 rounded-lg bg-emerald-100 dark:bg-emerald-500/10 ring-1 ring-emerald-200 dark:ring-emerald-500/20 text-emerald-600 dark:text-emerald-400 flex items-center justify-center">
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20.25 7.5l-.625 10.632a2.25 2.25 0 01-2.247 2.118H6.622a2.25 2.25 0 01-2.247-2.118L3.75 7.5m8.25 3v6.75m0 0l-3-3m3 3l3-3M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125z" />
                   </svg>
                 </div>
                 <h3 className="font-medium text-slate-900 dark:text-white">Bundle Size</h3>
               </div>
-              <div className="space-y-3 mb-4">
+              <div className="space-y-4 mb-5">
                 <div>
-                  <div className="flex justify-between text-sm mb-1">
+                  <div className="flex justify-between text-sm mb-1.5">
                     <span className="text-slate-600 dark:text-slate-400">forceCalendar <span className="text-xs text-slate-400 dark:text-slate-500">(core + interface)</span></span>
                     <span className="font-mono font-medium text-slate-900 dark:text-white">1.04 MB</span>
                   </div>
                   <div className="h-2 rounded-full bg-slate-100 dark:bg-slate-800 overflow-hidden">
-                    <div className="h-full rounded-full bg-emerald-500 dark:bg-emerald-400" style={{ width: "35%" }} />
+                    <div className="h-full rounded-full bg-gradient-to-r from-emerald-500 to-emerald-400" style={{ width: "35%" }} />
                   </div>
                 </div>
                 <div>
-                  <div className="flex justify-between text-sm mb-1">
+                  <div className="flex justify-between text-sm mb-1.5">
                     <span className="text-slate-600 dark:text-slate-400">FullCalendar <span className="text-xs text-slate-400 dark:text-slate-500">(core + 5 plugins + rrule)</span></span>
                     <span className="font-mono font-medium text-slate-900 dark:text-white">3.01 MB</span>
                   </div>
                   <div className="h-2 rounded-full bg-slate-100 dark:bg-slate-800 overflow-hidden">
-                    <div className="h-full rounded-full bg-slate-400 dark:bg-slate-500" style={{ width: "100%" }} />
+                    <div className="h-full rounded-full bg-slate-300 dark:bg-slate-600" style={{ width: "100%" }} />
                   </div>
                 </div>
               </div>
@@ -412,9 +464,9 @@ export default function Home() {
             </div>
 
             {/* Recurrence Performance */}
-            <div className="p-6 rounded-lg border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50">
-              <div className="flex items-center gap-3 mb-4">
-                <div className="w-8 h-8 rounded-lg bg-amber-100 dark:bg-amber-500/10 text-amber-600 dark:text-amber-400 flex items-center justify-center">
+            <div className="p-6 rounded-xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900/50">
+              <div className="flex items-center gap-3 mb-5">
+                <div className="w-9 h-9 rounded-lg bg-amber-100 dark:bg-amber-500/10 ring-1 ring-amber-200 dark:ring-amber-500/20 text-amber-600 dark:text-amber-400 flex items-center justify-center">
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M19.5 12c0-1.232-.046-2.453-.138-3.662a4.006 4.006 0 00-3.7-3.7 48.678 48.678 0 00-7.324 0 4.006 4.006 0 00-3.7 3.7c-.017.22-.032.441-.046.662M19.5 12l3-3m-3 3l-3-3m-12 3c0 1.232.046 2.453.138 3.662a4.006 4.006 0 003.7 3.7 48.656 48.656 0 007.324 0 4.006 4.006 0 003.7-3.7c.017-.22.032-.441.046-.662M4.5 12l3 3m-3-3l-3 3" />
                   </svg>
@@ -430,19 +482,44 @@ export default function Home() {
             </div>
           </div>
 
-          <div className="mt-8 text-center">
-            <p className="text-sm text-slate-400 dark:text-slate-500 mb-4">
+          <div className="mt-10 text-center">
+            <p className="text-sm text-slate-400 dark:text-slate-500 mb-5">
               Benchmarks run against published npm packages. Full methodology and interactive results available on the dashboard.
             </p>
             <a
               href="https://benchmark.forcecalendar.org"
-              className="inline-flex items-center gap-2 px-5 py-2.5 border border-slate-300 dark:border-slate-700 text-slate-700 dark:text-slate-300 text-sm font-medium rounded-lg hover:bg-slate-50 dark:hover:bg-slate-900 transition-colors"
+              className="inline-flex items-center gap-2 px-5 py-2.5 ring-1 ring-slate-300 dark:ring-slate-700 text-slate-700 dark:text-slate-300 text-sm font-medium rounded-lg hover:bg-slate-50 dark:hover:bg-slate-900 transition-colors"
             >
               View full benchmark
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
               </svg>
             </a>
+          </div>
+        </div>
+      </section>
+
+      {/* Final CTA */}
+      <section className="relative overflow-hidden border-t border-slate-200 dark:border-slate-800">
+        <div className="absolute inset-0 hero-glow" aria-hidden />
+        <div className="relative py-24 px-6 text-center">
+          <div className="max-w-2xl mx-auto">
+            <h2 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white">
+              Ship a calendar your security team will approve.
+            </h2>
+            <p className="mt-4 text-lg text-slate-500 dark:text-slate-400">
+              One audit, zero dependencies, MIT licensed. Up and running in minutes.
+            </p>
+            <div className="mt-8 flex flex-col sm:flex-row items-center justify-center gap-3">
+              <InstallCommand command="npm install @forcecalendar/core @forcecalendar/interface" />
+              <Link
+                href="/playground"
+                className="inline-flex items-center gap-2 px-5 py-3 bg-brand-600 text-white text-sm font-medium rounded-xl shadow-sm shadow-brand-600/25 hover:bg-brand-700 hover:shadow-md transition-all"
+              >
+                Try the playground
+                <span aria-hidden>&rarr;</span>
+              </Link>
+            </div>
           </div>
         </div>
       </section>

--- a/app/playground/page.tsx
+++ b/app/playground/page.tsx
@@ -16,22 +16,28 @@ export default function PlaygroundPage() {
       <Nav />
 
       {/* Header */}
-      <section className="pt-24 pb-8 px-6">
-        <div className="max-w-5xl mx-auto">
-          <div className="flex items-center gap-2 text-xs font-mono text-green-600 dark:text-green-400 uppercase tracking-wider mb-3">
-            <span className="w-2 h-2 bg-green-500 rounded-full" />
-            Live
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-grid" aria-hidden />
+        <div className="relative pt-24 pb-10 px-6">
+          <div className="max-w-5xl mx-auto">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-emerald-50 dark:bg-emerald-500/10 ring-1 ring-emerald-200 dark:ring-emerald-500/25 text-xs font-mono font-medium uppercase tracking-widest text-emerald-600 dark:text-emerald-400 mb-6">
+              <span className="relative flex w-2 h-2" aria-hidden>
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-emerald-400 opacity-75 motion-reduce:hidden" />
+                <span className="relative inline-flex rounded-full w-2 h-2 bg-emerald-500" />
+              </span>
+              Live
+            </div>
+            <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white mb-3">
+              Playground
+            </h1>
+            <p className="text-slate-500 dark:text-slate-400 max-w-2xl">
+              The real{" "}
+              <code className="text-sm font-mono text-cyan-600 dark:text-cyan-400">
+                @forcecalendar/interface
+              </code>{" "}
+              web component running live. Configure options and copy the output.
+            </p>
           </div>
-          <h1 className="text-3xl font-semibold text-slate-900 dark:text-white mb-2">
-            Playground
-          </h1>
-          <p className="text-slate-500 dark:text-slate-400">
-            The real{" "}
-            <code className="text-sm font-mono text-cyan-600 dark:text-cyan-400">
-              @forcecalendar/interface
-            </code>{" "}
-            web component running live. Configure options and copy the output.
-          </p>
         </div>
       </section>
 

--- a/app/salesforce/page.tsx
+++ b/app/salesforce/page.tsx
@@ -24,18 +24,21 @@ export default function SalesforcePage() {
       <Nav />
 
       {/* Hero */}
-      <section className="pt-24 pb-16 px-6">
-        <div className="max-w-3xl mx-auto">
-          <div className="text-xs font-mono uppercase tracking-wider text-brand-600 dark:text-brand-400 mb-4">
-            Salesforce Integration
+      <section className="relative overflow-hidden">
+        <div className="absolute inset-0 bg-grid" aria-hidden />
+        <div className="relative pt-24 pb-16 px-6">
+          <div className="max-w-3xl mx-auto">
+            <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-brand-50 dark:bg-brand-500/10 ring-1 ring-brand-200 dark:ring-brand-500/25 text-xs font-mono font-medium uppercase tracking-widest text-brand-600 dark:text-brand-400 mb-6">
+              Salesforce Integration
+            </div>
+            <h1 className="text-3xl sm:text-5xl font-semibold tracking-tight text-slate-900 dark:text-white leading-tight">
+              Install forceCalendar on Salesforce
+            </h1>
+            <p className="mt-5 text-lg sm:text-xl text-slate-500 dark:text-slate-400 max-w-2xl">
+              One-click install via unlocked package. Includes LWC components, Apex
+              controller, and the bundled static resource. No code required.
+            </p>
           </div>
-          <h1 className="text-3xl sm:text-4xl font-semibold tracking-tight text-slate-900 dark:text-white leading-tight">
-            Install forceCalendar on Salesforce
-          </h1>
-          <p className="mt-4 text-lg text-slate-500 dark:text-slate-400 max-w-2xl">
-            One-click install via unlocked package. Includes LWC components, Apex
-            controller, and the bundled static resource. No code required.
-          </p>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
Full visual refresh of forcecalendar.org keeping the established design guidelines (slate palette, brand blue accent, Inter, class-based dark mode) while modernizing every surface:

- **Hero**: blueprint-grid + radial brand glow backdrop, status badge pill, gradient accent on the headline, and a stats strip (0 deps · 2.9x smaller · 35+ tokens · MIT)
- **Sections**: eyebrow labels, larger type, alternating tinted bands for rhythm instead of uniform `border-t` dividers
- **Cards**: `rounded-xl`, ring-accented icon tiles, hover lift + soft shadows
- **CodeBlock**: terminal chrome with traffic-light dots; **InstallCommand**: refined pill with framed copy button
- **Nav/Footer**: taller blurred nav with pill active states; tinted footer with badge chips
- **Package pages** (core/interface/salesforce/playground): consistent hero treatment with accent chips and grid backdrop
- New closing CTA section

No logic changes — all interactivity (theme, dropdown, mobile menu, playground) untouched.

## Test plan
- `npm run lint`: 0 errors
- `npm run build`: passes, 10/10 pages generate
- Light + dark mode classes paired on every new utility; `prefers-reduced-motion` respected (live-pulse animation disabled via `motion-reduce:hidden`)